### PR TITLE
fix(build): remove scrypt dependency for yarn build

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react-scripts": "3.1.1",
     "recharts": "^1.8.5",
     "satoshi-bitcoin": "^1.0.4",
-    "scrypt": "^6.0.3",
     "wallet-address-validator": "^0.2.4",
     "web3": "^1.2.1",
     "web3-detect-network": "0.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13201,7 +13201,7 @@ scrypt.js@^0.3.0:
   optionalDependencies:
     scrypt "^6.0.2"
 
-scrypt@^6.0.2, scrypt@^6.0.3:
+scrypt@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/scrypt/-/scrypt-6.0.3.tgz#04e014a5682b53fa50c2d5cce167d719c06d870d"
   integrity sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=


### PR DESCRIPTION
The scrypt dependency fails to build on node 12 on Netlify, this PR removes it. Needed to complete #1 