### PR TITLE
chore(ci): deploy production on tag

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -1,0 +1,24 @@
+name: CD
+
+# Run when tags are pushed
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2.1.0
+    - name: Install dependencies
+      run: yarn --network-concurrency 1
+    - run: REACT_APP_FB_KEY=${{ secrets.REACT_APP_FB_KEY }} CI=false yarn build
+    - uses: netlify/actions/cli@master
+      with:
+        args: deploy --dir=./build
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
When a tag is pushed, build the app and deploy a preview to Netlify at https://wbtc-cafe-production.netlify.app