### PR TITLE
fix(security): security headers for additional resilience

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,6 @@
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  Content-Security-Policy: script-src 'self'
+  X-Content-Type-Options "nosniff" always;
+  Referrer-Policy: no-referrer


### PR DESCRIPTION
In order to improve the Netlify based deployments, we can set additional headers that will prevent browsers from performing insecure actions, allow WBTC.cafe from being loaded in an iframe or load scripts from external sources. 