### PR TITLE
Fix(walletconnect): disable walletconnect

### DIFF
--- a/src/utils/txUtils.js
+++ b/src/utils/txUtils.js
@@ -389,25 +389,26 @@ export const completeConvertToEthereum = async function (
     );
     try {
       let gasParams = {};
-      const contractCall = adapterContract.methods
-            .mintThenSwap(
-              params.contractCalls[0].contractParams[0].value,
-              newMinExchangeRate,
-              params.contractCalls[0].contractParams[1].value,
-              params.contractCalls[0].contractParams[2].value,
-              utxoAmountSats,
-              renResponse.autogen.nhash,
-              renSignature
-            );
+      const contractCall = adapterContract.methods.mintThenSwap(
+        params.contractCalls[0].contractParams[0].value,
+        newMinExchangeRate,
+        params.contractCalls[0].contractParams[1].value,
+        params.contractCalls[0].contractParams[2].value,
+        utxoAmountSats,
+        renResponse.autogen.nhash,
+        renSignature
+      );
       if (localWeb3.currentProvider.isWalletConnect) {
         gasParams = {
-          gas: await contractCall.estimateGas({ from: localWeb3Address }) + 1000,
+          gas:
+            (await contractCall.estimateGas({ from: localWeb3Address })) + 1000,
           gasPrice: await localWeb3.eth.getGasPrice(),
-          nonce: await localWeb3.eth.getTransactionCount(localWeb3Address)
+          nonce: await localWeb3.eth.getTransactionCount(localWeb3Address),
         };
-        console.log('setting gas params', gasParams)
+        console.log("setting gas params", gasParams);
       }
-      await contractCall.send({
+      await contractCall
+        .send({
           from: localWeb3Address,
           ...gasParams,
         })
@@ -707,25 +708,24 @@ export const initConvertFromEthereum = async function (tx) {
   }
 
   try {
-
     let gasParams = {};
-    const contractCall = adapter.methods
-          .swapThenBurn(
-            RenJS.utils.BTC.addressToHex(destAddress), //_to
-            RenJS.utils.value(amount, "btc").sats().toNumber().toFixed(0), // _amount in Satoshis
-            RenJS.utils.value(minSwapProceeds, "btc").sats().toNumber().toFixed(0)
-          );
+    const contractCall = adapter.methods.swapThenBurn(
+      RenJS.utils.BTC.addressToHex(destAddress), //_to
+      RenJS.utils.value(amount, "btc").sats().toNumber().toFixed(0), // _amount in Satoshis
+      RenJS.utils.value(minSwapProceeds, "btc").sats().toNumber().toFixed(0)
+    );
     if (web3.currentProvider.isWalletConnect) {
       gasParams = {
-        gas: await contractCall.estimateGas({ from }) + 1000,
+        gas: (await contractCall.estimateGas({ from })) + 1000,
         gasPrice: await web3.eth.getGasPrice(),
-        nonce: await web3.eth.getTransactionCount(from)
+        nonce: await web3.eth.getTransactionCount(from),
       };
     }
-    await contractCall.send({
-      from,
-      ...gasParams,
-    })
+    await contractCall
+      .send({
+        from,
+        ...gasParams,
+      })
       .on("transactionHash", (hash) => {
         // console.log(hash)
         updateTx(

--- a/src/utils/walletUtils.js
+++ b/src/utils/walletUtils.js
@@ -162,21 +162,24 @@ export const initLocalWeb3 = async function () {
   const db = store.get("db");
   const fsUser = store.get("fsUser");
   const disclosureAccepted = store.get("disclosureAccepted");
-  const walletConnectEnabled = (store.get('queryParams') ?? {}).walletConnect ?? false;
+  const walletConnectEnabled =
+    (store.get("queryParams") ?? {}).walletConnect ?? false;
 
-  const providerOptions = walletConnectEnabled ? {
-    walletconnect: {
-      package: WalletConnectProvider, // required
-      display: {
-        name: "WalletConnect",
-        description: "BETA - not all WalletConnect wallets are supported, use with caution"
-      },
-      options: {
-        infuraId: "6de9092ee3284217bb744cc1a6daab94", // required
-      },
-    },
-  } : {
-  };
+  const providerOptions = walletConnectEnabled
+    ? {
+        walletconnect: {
+          package: WalletConnectProvider, // required
+          display: {
+            name: "WalletConnect",
+            description:
+              "BETA - not all WalletConnect wallets are supported, use with caution",
+          },
+          options: {
+            infuraId: "6de9092ee3284217bb744cc1a6daab94", // required
+          },
+        },
+      }
+    : {};
 
   const web3Modal = new Web3Modal({
     network: selectedNetwork === "testnet" ? "kovan" : "mainnet", // optional

--- a/src/utils/walletUtils.js
+++ b/src/utils/walletUtils.js
@@ -162,14 +162,20 @@ export const initLocalWeb3 = async function () {
   const db = store.get("db");
   const fsUser = store.get("fsUser");
   const disclosureAccepted = store.get("disclosureAccepted");
+  const walletConnectEnabled = (store.get('queryParams') ?? {}).walletConnect ?? false;
 
-  const providerOptions = {
+  const providerOptions = walletConnectEnabled ? {
     walletconnect: {
       package: WalletConnectProvider, // required
+      display: {
+        name: "WalletConnect",
+        description: "BETA - not all WalletConnect wallets are supported, use with caution"
+      },
       options: {
         infuraId: "6de9092ee3284217bb744cc1a6daab94", // required
       },
     },
+  } : {
   };
 
   const web3Modal = new Web3Modal({


### PR DESCRIPTION
This PR disables WalletConnect by default, in order to prevent new users from creating transactions with problematic WalletConnect implementations. 

WalletConnect can still be accessed with the `?walletConnectEnabled=true` query parameter.